### PR TITLE
Improvements to body copy styles

### DIFF
--- a/source/stylesheets/base/_lists.scss
+++ b/source/stylesheets/base/_lists.scss
@@ -8,6 +8,10 @@ ol {
     list-style-type: disc;
     margin-bottom: $small-spacing;
     padding-left: $base-spacing;
+
+    > li {
+      padding: ($small-spacing / 2) 0;
+    }
   }
 
   &%default-ol {

--- a/source/stylesheets/base/_typography.scss
+++ b/source/stylesheets/base/_typography.scss
@@ -59,3 +59,7 @@ picture {
   margin: 0;
   max-width: 100%;
 }
+
+figure {
+  text-align: center;
+}

--- a/source/stylesheets/components/_article.scss
+++ b/source/stylesheets/components/_article.scss
@@ -21,6 +21,20 @@ article {
     }
   }
 
+  h2,
+  h3 {
+    margin-top: $large-spacing;
+  }
+
+  hr + h2,
+  hr + h3 {
+    margin-top: 0;
+  }
+
+  h4 {
+    margin-top: $base-spacing;
+  }
+
   ul {
     @extend %default-ul;
   }
@@ -35,15 +49,21 @@ article {
     margin-top: 5em;
     padding: $base-spacing 0;
 
+    a {
+      &::before,
+      &::after {
+        display: inline-block;
+        font-weight: 700;
+        margin: 0 0.5em;
+        transition: transform $duration;
+      }
+    }
+
     .previous-guide {
       float: left;
 
       &::before {
         content: "\2039";
-        display: inline-block;
-        font-weight: 700;
-        margin: 0 0.5em;
-        transition: transform $duration;
       }
 
       &:hover::before {
@@ -56,30 +76,11 @@ article {
 
       &::after {
         content: "\203A";
-        display: inline-block;
-        font-weight: 700;
-        margin: 0 0.5em;
-        transition: transform $duration;
       }
 
       &:hover::after {
         transform: translateX(0.5em);
       }
     }
-  }
-}
-
-.anchorable-tock {
-  h2#{&},
-  h3#{&} {
-    margin-top: $large-spacing;
-  }
-
-  h4#{&} {
-    margin-top: $base-spacing;
-  }
-
-  hr + & {
-    margin-top: 0;
   }
 }

--- a/source/stylesheets/components/_sidebar.scss
+++ b/source/stylesheets/components/_sidebar.scss
@@ -32,6 +32,10 @@ li.toc-level-0 {
     display: block;
     line-height: 1.25;
     padding: 0.33em 0;
+
+    &:hover {
+      color: $ember-orange;
+    }
   }
 
   > a {
@@ -50,9 +54,15 @@ ol.toc-level-1 {
 
   li {
     border-left: 3px solid transparent;
+    transition: border-width $duration;
 
-    &.selected {
+    &.selected,
+    &:hover {
       border-left-color: $base-border-color;
+    }
+
+    &:hover {
+      border-left-width: 6px;
     }
   }
 


### PR DESCRIPTION
Small updates to body copy styles:
- More spacing for unordered lists for better readability
- Center examples images
- Improve spacing before sections
- Nice little animation and hover state for sidebar to make it easier to navigate
